### PR TITLE
chore(deps): upgrade rust to 1.85 and bump edition to 2024

### DIFF
--- a/esp32/Cargo.toml
+++ b/esp32/Cargo.toml
@@ -1,11 +1,13 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "weather-landscape"
 version = "0.1.0"
 authors = ["martinohmann <martinohmann@gmail.com>"]
 repository = "https://github.com/martinohmann/weather-landscape"
-edition = "2021"
+edition = "2024"
 resolver = "2"
-rust-version = "1.77"
+rust-version = "1.84"
 
 [[bin]]
 name = "weather-landscape"

--- a/esp32/src/http.rs
+++ b/esp32/src/http.rs
@@ -1,7 +1,7 @@
 use super::display_buffer_size;
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use embedded_svc::{
-    http::{client::Client, Method},
+    http::{Method, client::Client},
     utils::io,
 };
 use esp_idf_svc::{

--- a/esp32/src/main.rs
+++ b/esp32/src/main.rs
@@ -12,7 +12,7 @@ use esp_idf_hal::{
     delay::Ets,
     gpio::{AnyIOPin, Gpio2, PinDriver},
     prelude::*,
-    spi::{config::Config as SpiConfig, SpiDeviceDriver, SpiDriverConfig},
+    spi::{SpiDeviceDriver, SpiDriverConfig, config::Config as SpiConfig},
 };
 use esp_idf_svc::{eventloop::EspSystemEventLoop, nvs::EspDefaultNvsPartition};
 use log::{error, info};

--- a/esp32/src/wifi.rs
+++ b/esp32/src/wifi.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use esp_idf_svc::{
     eventloop::EspSystemEventLoop,
     hal::modem::Modem,

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -3,7 +3,7 @@ name = "weather-landscape-server"
 version = "0.1.0"
 authors = ["martinohmann <martinohmann@gmail.com>"]
 repository = "https://github.com/martinohmann/weather-landscape"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 actix-web = "4.9.0"

--- a/server/src/app.rs
+++ b/server/src/app.rs
@@ -1,7 +1,8 @@
 use crate::{config::Config, error::Result, graphics::Renderer, weather::Weather};
 use prometheus::{
+    IntCounterVec, Registry,
     core::{AtomicU64, GenericCounter},
-    opts, IntCounterVec, Registry,
+    opts,
 };
 
 /// Holds the application state.

--- a/server/src/graphics/img.rs
+++ b/server/src/graphics/img.rs
@@ -6,7 +6,7 @@ use epd_waveshare::{
     epd2in9_v2::{HEIGHT, WIDTH},
     graphics::VarDisplay,
 };
-use image::{imageops, Pixel, Rgba, RgbaImage};
+use image::{Pixel, Rgba, RgbaImage, imageops};
 use serde::Deserialize;
 use std::{
     io::Cursor,

--- a/server/src/graphics/mod.rs
+++ b/server/src/graphics/mod.rs
@@ -4,7 +4,7 @@ mod sprites;
 pub use self::img::{Image, ImageFormat};
 use self::{
     img::{BLACK, TRANSPARENT, WHITE},
-    sprites::{sprite, spriten, Sprite},
+    sprites::{Sprite, sprite, spriten},
 };
 use crate::{
     app::Metrics,
@@ -14,8 +14,8 @@ use crate::{
 };
 use epd_waveshare::epd2in9_v2::{HEIGHT, WIDTH};
 use imageproc::drawing::BresenhamLineIter;
-use jiff::{civil::time, tz::TimeZone, SignedDuration, Timestamp};
-use rand::{seq::SliceRandom, Rng};
+use jiff::{SignedDuration, Timestamp, civil::time, tz::TimeZone};
+use rand::{Rng, seq::SliceRandom};
 use std::collections::BTreeMap;
 use tracing::debug;
 

--- a/server/src/graphics/sprites.rs
+++ b/server/src/graphics/sprites.rs
@@ -1,6 +1,6 @@
 use super::{BLACK, TRANSPARENT, WHITE};
 use crate::error::Result;
-use image::{imageops, RgbaImage};
+use image::{RgbaImage, imageops};
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::OnceLock;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -12,11 +12,10 @@ use crate::{
     graphics::ImageFormat,
 };
 use actix_web::{
-    get,
+    App, HttpResponse, HttpServer, get,
     http::header::ContentType,
     middleware::Logger,
     web::{Data, Path, Query},
-    App, HttpResponse, HttpServer,
 };
 use actix_web_prom::PrometheusMetricsBuilder;
 use serde::Deserialize;

--- a/server/src/weather.rs
+++ b/server/src/weather.rs
@@ -1,16 +1,16 @@
 use crate::error::{Error, Result};
 use jiff::Timestamp;
 use monsoon::{
-    body::{Body, TimeSeries},
     Monsoon, Params, Response,
+    body::{Body, TimeSeries},
 };
-use rand::{seq::SliceRandom, Rng};
+use rand::{Rng, seq::SliceRandom};
 use std::time::Duration;
 use std::{str::FromStr, sync::Arc};
 use tokio::sync::Mutex;
 use tower::{
-    limit::{ConcurrencyLimit, RateLimit},
     Service, ServiceBuilder, ServiceExt,
+    limit::{ConcurrencyLimit, RateLimit},
 };
 use tracing::info;
 


### PR DESCRIPTION
https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html

esp toolchain is still on rust 1.84 but we're using the new edition via nightly features.